### PR TITLE
Static imports jsDelivr have to use https: (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ folder as `voyager.min.js`.
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
-    <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
 
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-voyager/dist/voyager.css" />
-    <script src="//cdn.jsdelivr.net/npm/graphql-voyager/dist/voyager.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-voyager/dist/voyager.css" />
+    <script src="https://cdn.jsdelivr.net/npm/graphql-voyager/dist/voyager.min.js"></script>
   </head>
   <body>
     <div id="voyager">Loading...</div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -76,8 +76,8 @@
     }
   </style>
 
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.js"></script>
+  <script src="https://cdn.jsdelivr.net/react/15.4.2/react.js"></script>
+  <script src="https://cdn.jsdelivr.net/react/15.4.2/react-dom.js"></script>
 </head>
 <body>
   <main id="panel_root">

--- a/src/middleware/render-voyager-page.ts
+++ b/src/middleware/render-voyager-page.ts
@@ -29,12 +29,12 @@ export default function renderVoyagerPage(options: MiddlewareOptions) {
     }
   </style>
   <link rel="stylesheet"
-    href="//cdn.jsdelivr.net/npm/graphql-voyager@${version}/dist/voyager.css"
+    href="https://cdn.jsdelivr.net/npm/graphql-voyager@${version}/dist/voyager.css"
   />
-  <script src="//cdn.jsdelivr.net/fetch/2.0.1/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/graphql-voyager@${version}/dist/voyager.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/fetch/2.0.1/fetch.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/graphql-voyager@${version}/dist/voyager.min.js"></script>
 </head>
 <body>
   <main id="voyager">


### PR DESCRIPTION
jsdelivr.com does not support http anymore, so all the reference in the dode like:
`<script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>`
have to be updated to:
`<script src="https://cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>`